### PR TITLE
Update LZMAEncoder.cpp to fix compiler warning about indentation

### DIFF
--- a/C/7zip/Compress/LZMA/LZMAEncoder.cpp
+++ b/C/7zip/Compress/LZMA/LZMAEncoder.cpp
@@ -968,7 +968,7 @@ HRESULT CEncoder::GetOptimum(UInt32 position, UInt32 &backRes, UInt32 &lenRes)
         startLen = lenTest + 1;
 
       // if (_maxMode)
-        {
+      {
           UInt32 lenTest2 = lenTest + 1;
           UInt32 limit = MyMin(numAvailableBytesFull, lenTest2 + _numFastBytes);
           for (; lenTest2 < limit &&
@@ -1011,7 +1011,7 @@ HRESULT CEncoder::GetOptimum(UInt32 position, UInt32 &backRes, UInt32 &lenRes)
             }
           }
         }
-      }
+    }
 
     //    for(UInt32 lenTest = 2; lenTest <= newLen; lenTest++)
     if (newLen > numAvailableBytes)


### PR DESCRIPTION
Enabling warning -Wmisleading-indentation has problems with the indenting in the referenced file.

This fix corrects the indentation, as per patches in other repos:
https://www.mail-archive.com/grub-devel@gnu.org/msg30485.html
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=244636