### PR TITLE
MyCom.h: fix build with gcc-11

### DIFF
--- a/C/Common/MyCom.h
+++ b/C/Common/MyCom.h
@@ -156,8 +156,7 @@ public:
 
 #define MY_ADDREF_RELEASE \
 STDMETHOD_(ULONG, AddRef)() { return ++__m_RefCount; } \
-STDMETHOD_(ULONG, Release)() { if (--__m_RefCount != 0)  \
-  return __m_RefCount; delete this; return 0; }
+STDMETHOD_(ULONG, Release)() { if (--__m_RefCount != 0) return __m_RefCount; delete this; return 0; }
 
 #define MY_UNKNOWN_IMP_SPEC(i) \
   MY_QUERYINTERFACE_BEGIN \


### PR DESCRIPTION
* fixes:
  ./../src/lzma-sdk/C/7zip/Compress/LZMA/LZMAEncoder.h: In member function 'virtual ULONG NCompress::NLZMA::CEncoder::Release()':
  ./../src/lzma-sdk/C/7zip/Compress/LZMA/../../../Common/MyCom.h:159:32: error: this 'if' clause does not guard... [-Werror=misleading-indentation]
    159 | STDMETHOD_(ULONG, Release)() { if (--__m_RefCount != 0)  \
        |                                ^~

Signed-off-by: Martin Jansa <martin.jansa@lge.com>